### PR TITLE
Avoid using else

### DIFF
--- a/examples/ProviderUnlock/OnOfficeUnlockProviderIFrame.php
+++ b/examples/ProviderUnlock/OnOfficeUnlockProviderIFrame.php
@@ -55,10 +55,12 @@
 		{
 			$pCheckUrlSignature = new checkUrlSignature();
 
+			$inUrl = "http";
+
 			if(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on')
+			{
 				$inUrl = "https";
-			else
-				$inUrl = "http";
+			}
 
 			$inUrl .= "://";
 			$inUrl .= $_SERVER['HTTP_HOST'];

--- a/examples/ProviderUnlock/OnOfficeUnlockProviderIFrame.php
+++ b/examples/ProviderUnlock/OnOfficeUnlockProviderIFrame.php
@@ -36,12 +36,9 @@
 			if ($this->checkSignature())
 			{
 				$this->printHtml();
+				return;
 			}
-			else
-
-			{
-				$this->printErrorMessage();
-			}
+			$this->printErrorMessage();
 		}
 
 		/**


### PR DESCRIPTION
Using the `else` keyword is not necessary in the current code. So we can get rid of it to improve the code readability.